### PR TITLE
Mirtarbase

### DIFF
--- a/ModulectorBackend/urls.py
+++ b/ModulectorBackend/urls.py
@@ -12,6 +12,8 @@ urlpatterns = [
     path('mirna/', views.MirnaList.as_view({'get': 'list'}), name='mirna'),
     path('mirna-target-interactions/', views.MirnaTargetInteractions.as_view(),
          name='mirna_target_interactions'),
+    path('mirna-target-validation/', views.MirnaTargetValidation.as_view(),
+         name='mirna_target_validation'),
     path('mirna-aliases/', views.MirnaAliasesList.as_view(), name='mirna_aliases'),
     path('mirna-codes/', views.MirnaCodes.as_view(), name='mirna_codes'),
     path('mirna-codes-finder/', views.MirnaCodesFinder.as_view(),

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Document content:
     - [Combining functions](#combining-functions)
   - [Services](#services)
     - [MiRNA target interactions](#mirna-target-interactions)
+    - [MiRNA target validation](#mirna-target-validation)
     - [MiRNA details](#mirna-details)
     - [MiRNA aliases](#mirna-aliases)
     - [MiRNA codes finder](#mirna-codes-finder)
@@ -44,7 +45,9 @@ Modulector obtains information from different bioinformatics databases or resour
    miRBase is a searchable database of published miRNA sequences and annotations. Each entry in the miRBase Sequence database represents a predicted hairpin portion of a miRNA transcript (termed hairpin in the database), with information on the location and sequence of the mature miRNA (termed mature). Modulector uses miRBase 22.1.  
 3. Relationship data between miRNA and diseases: [HMDD: the Human microRNA Disease Database](https://www.cuilab.cn/hmdd).  
    Increasing reports have shown that miRNAs play important roles in various critical biological processes. For their importance, the dysfunctions of miRNAs are associated with a broad spectrum of diseases. The Human microRNA Disease Database (HMDD) is a database that curated experiment-supported evidence for human microRNA (miRNA) and disease associations. Modulector uses HMDD v4.0.
-4. Relationship data between miRNA and drugs: [SM2miR Database](http://www.jianglab.cn/SM2miR/).
+4. miRNA target validation data: [miRTarBase: the experimentally validated microRNA-target interactions database](https://awi.cuhk.edu.cn/miRTarBase/).  
+   miRTarBase is a manually curated database of experimentally validated miRNA-target interactions. Modulector uses MirTarBase version 11.0.  
+5. Relationship data between miRNA and drugs: [SM2miR Database](http://www.jianglab.cn/SM2miR/).
    Many studies have demonstrated that bioactive small molecules (or drugs) can regulate miRNA expression, which indicates that targeting miRNAs with small molecules is a new type of therapy for human diseases. SM2miR is a manually curated database that collects and incorporates the experimentally validated small molecules' effects on miRNA expression in 21 species from the published papers. Modulector uses leaked data from the SM2miR database for Homo Sapiens, in the version released on Apr. 27, 2015.
 5. Methylation data: Illumina [Infinium MethylationEPIC 2.0](https://www.illumina.com/products/by-type/microarray-kits/infinium-methylation-epic.html) array.  
    The Infinium MethylationEPIC v2.0 BeadChip Kit is a genome-wide methylation screening tool that targets over 935,000 CpG sites in the most biologically significant regions of the human methylome. At Modulector we use the information provided by Illumina on its [product files](https://support.illumina.com/downloads/infinium-methylationepic-v2-0-product-files.html) website.  
@@ -244,6 +247,63 @@ If no gene symbol is entered, all miRNA interactions are returned. If a miRNA is
                     "MiRNATIP"
                 ],
                 "score_class":"M"
+            }
+        ]
+      }
+    ```  
+
+- Error Response:
+  - Code: 400
+  - Content: `detail`: error description
+
+### MiRNA target validation
+
+Receives a miRNA and/or a gene symbol (target) and returns a paginated vector. Each vector entry represents a miRNA-Gene experimentally validated interaction in miRTarBase.
+If no gene symbol is entered, all experimentally validated targets for that miRNA are returned. If a miRNA is not entered, all miRNA interactions for that target are returned. If both are entered, the interactions of the mirna with the target are returned.
+
+- URL: `/mirna-target-validation`
+- Query params:
+  - `mirna`: miRNA to get its targets validation.
+  - `target`: Gene symbol (target) to get its interactions with different miRNAs.
+  - `support_type`: filter the validations by the type of support. Possible values: `Functional MTI`, `Functional MTI (Weak)`, `Non-Functional MTI`, `Non-Functional MTI (Weak)`.
+  - `experiment`: filter the validations by the type of experiment (e.g. `Western blot`). Case insensitive, partial match is supported.  
+  *NOTE*: `mirna` or `target` are required
+- Functions:
+  - Ordering fields: `mirna` and `gene`
+  - Filtering fields: `support_type` and `experiment`
+  - Searching fields: searching is not available for this service
+  - Pagination: yes
+- Success Response:
+  - Code: 200
+  - Content:
+    - `mirtarbase_id`: miRTarBase interaction ID.
+    - `mirna`: standardized miRNA ID.
+    - `gene`: target gene.
+    - `target_gene_entrez_id`: target gene Entrez ID.
+    - `experiments`: array of experiments validating the interaction.
+    - `support_type`: type of experimental support.
+    - `pmid`: PubMed ID of the publication supporting the validation.
+  - Example:
+    - URL: <https://modulector.multiomix.org/mirna-target-validation/?mirna=hsa-miR-122-5p&target=SLC7A1>
+    - Response:
+
+    ```JSON
+      {
+        "count": 1,
+        "next": null,
+        "previous": null,
+        "results": [
+            {
+                "mirtarbase_id": "MIRT003105",
+                "mirna": "hsa-miR-122-5p",
+                "gene": "SLC7A1",
+                "target_gene_entrez_id": "6541.0",
+                "experiments": [
+                    "Luciferase reporter assay",
+                    "Western blot"
+                ],
+                "support_type": "Functional MTI",
+                "pmid": "17179747.0"
             }
         ]
       }

--- a/README.md
+++ b/README.md
@@ -270,17 +270,18 @@ If no gene symbol is entered, all experimentally validated targets for that miRN
   *NOTE*: `mirna` or `target` are required
 - Functions:
   - Ordering fields: `mirna` and `gene`
-  - Filtering fields: `support_type` and `experiment`
+  - Filtering fields: `mirna`, `target`, and `support_type` (exact match), and `experiment` (case-insensitive, partial match)
   - Searching fields: searching is not available for this service
   - Pagination: yes
 - Success Response:
   - Code: 200
   - Content:
+    - `id`: Internal ID of the record. 
     - `mirtarbase_id`: miRTarBase interaction ID.
     - `mirna`: standardized miRNA ID.
     - `gene`: target gene.
     - `target_gene_entrez_id`: target gene Entrez ID.
-    - `experiments`: array of experiments validating the interaction.
+    - `experiments`: array of techniques used to experimentally validate the miRNA-target interaction.
     - `support_type`: type of experimental support.
     - `pmid`: PubMed ID of the publication supporting the validation.
   - Example:
@@ -294,6 +295,7 @@ If no gene symbol is entered, all experimentally validated targets for that miRN
         "previous": null,
         "results": [
             {
+                "id": 10,
                 "mirtarbase_id": "MIRT003105",
                 "mirna": "hsa-miR-122-5p",
                 "gene": "SLC7A1",

--- a/modulector/migrations/0043_mirtarbase_1915.py
+++ b/modulector/migrations/0043_mirtarbase_1915.py
@@ -4,6 +4,7 @@ import os
 import pathlib
 import csv
 from django.db import migrations, models
+import django.contrib.postgres.fields
 from tqdm import tqdm
 
 
@@ -33,11 +34,19 @@ def load_mirtarbase_data(apps, _schema_editor):
             raw_pmid = row.get('References (PMID)', '')
             clean_pmid = str(int(float(raw_pmid))) if raw_pmid and str(raw_pmid).lower() != 'nan' else ''
 
+            # Clean Entrez ID (from "6541.0" to "6541")
+            raw_entrez = row.get('Target Gene (Entrez ID)', '')
+            clean_entrez = str(int(float(raw_entrez))) if raw_entrez and str(raw_entrez).lower() != 'nan' else ''
+
+            raw_experiments = row.get('Experiments', '')
+            experiments_list = [exp.strip() for exp in raw_experiments.split('//') if exp.strip()] if raw_experiments else []
+
             records.append(MirTarBaseInteraction(
                 mirtarbase_id=row.get('miRTarBase ID', ''),
                 mirna=row.get('miRNA', ''),
                 gene=row.get('Target Gene', ''),
-                experiments=row.get('Experiments', ''),
+                target_gene_entrez_id=clean_entrez,
+                experiments=experiments_list,
                 support_type=row.get('Support Type', ''),
                 pmid=clean_pmid
             ))
@@ -64,7 +73,8 @@ class Migration(migrations.Migration):
                 ('mirtarbase_id', models.CharField(max_length=50)),
                 ('mirna', models.CharField(db_index=True, max_length=100)),
                 ('gene', models.CharField(db_index=True, max_length=100)),
-                ('experiments', models.TextField()),
+                ('target_gene_entrez_id', models.CharField(blank=True, max_length=50, null=True)),
+                ('experiments', django.contrib.postgres.fields.ArrayField(base_field=models.CharField(max_length=200), help_text='List of experiments', size=None)),
                 ('support_type', models.CharField(max_length=100)),
                 ('pmid', models.CharField(max_length=50)),
             ],
@@ -72,5 +82,5 @@ class Migration(migrations.Migration):
                 'indexes': [models.Index(fields=['mirna', 'gene'], name='modulector__mirna_8c339f_idx')],
             },
         ),
-        migrations.RunPython(load_mirtarbase_data),
+        migrations.RunPython(load_mirtarbase_data, reverse_code=migrations.RunPython.noop),
     ]

--- a/modulector/migrations/0043_mirtarbase_1915.py
+++ b/modulector/migrations/0043_mirtarbase_1915.py
@@ -4,7 +4,7 @@ import os
 import pathlib
 import csv
 from django.db import migrations, models
-import django.contrib.postgres.fields
+from django.contrib.postgres.fields import ArrayField
 from tqdm import tqdm
 
 
@@ -74,7 +74,7 @@ class Migration(migrations.Migration):
                 ('mirna', models.CharField(db_index=True, max_length=100)),
                 ('gene', models.CharField(db_index=True, max_length=100)),
                 ('target_gene_entrez_id', models.CharField(blank=True, max_length=50, null=True)),
-                ('experiments', django.contrib.postgres.fields.ArrayField(base_field=models.CharField(max_length=200), help_text='List of experiments', size=None)),
+                ('experiments', ArrayField(base_field=models.CharField(max_length=200), help_text='List of experiments', size=None)),
                 ('support_type', models.CharField(max_length=100)),
                 ('pmid', models.CharField(max_length=50)),
             ],

--- a/modulector/models.py
+++ b/modulector/models.py
@@ -1,5 +1,6 @@
 from typing import Optional
 from django.db import models
+from django.contrib.postgres.fields import ArrayField
 from django.db.models import QuerySet
 
 
@@ -232,9 +233,13 @@ class MirTarBaseInteraction(models.Model):
     mirtarbase_id = models.CharField(max_length=50) 
     mirna = models.CharField(max_length=100, db_index=True)
     gene = models.CharField(max_length=100, db_index=True)
+    target_gene_entrez_id = models.CharField(max_length=50, null=True, blank=True)
 
-    # Stored as a string in the database (e.g.: "Reporter assay//Western blot")
-    experiments = models.TextField()
+    # Stored as an array of strings in the database
+    experiments = ArrayField(
+        models.CharField(max_length=200),
+        help_text="List of experiments"
+    )
 
     support_type = models.CharField(max_length=100)
     pmid = models.CharField(max_length=50)

--- a/modulector/models.py
+++ b/modulector/models.py
@@ -238,7 +238,7 @@ class MirTarBaseInteraction(models.Model):
     # Stored as an array of strings in the database
     experiments = ArrayField(
         models.CharField(max_length=200),
-        help_text="List of experiments"
+        help_text="List of techniques used to experimentally validate the miRNA-target interaction"
     )
 
     support_type = models.CharField(max_length=100)

--- a/modulector/serializers.py
+++ b/modulector/serializers.py
@@ -240,7 +240,7 @@ class MirTarBaseInteractionSerializer(serializers.ModelSerializer):
     class Meta:
         model = MirTarBaseInteraction
         fields = [
-            'mirtarbase_id', 'mirna', 'gene', 
+            'id', 'mirtarbase_id', 'mirna', 'gene', 
             'target_gene_entrez_id', 'experiments', 
             'support_type', 'pmid'
         ]

--- a/modulector/serializers.py
+++ b/modulector/serializers.py
@@ -4,7 +4,7 @@ from typing import List, Optional, Dict, Set
 from django.db.models import Q
 from rest_framework import serializers
 from ModulectorBackend.settings import USE_PUBMED_API, PUBMED_API_TIMEOUT
-from modulector.models import MirnaXGene, MirnaSource, Mirna, MirnaColumns, MirbaseIdMirna, MirnaDisease, MirnaDrug
+from modulector.models import MirnaXGene, MirnaSource, Mirna, MirnaColumns, MirbaseIdMirna, MirnaDisease, MirnaDrug, MirTarBaseInteraction
 from modulector.services import url_service, pubmed_service
 from modulector.utils import link_builder
 
@@ -234,3 +234,14 @@ def get_accession_from_mirna(mirna_code: str) -> Optional[str]:
         Q(previous_mature_mirna=mirna_code)
     ).only('mirbase_accession_id').first()
     return record.mirbase_accession_id if record is not None else None
+
+
+class MirTarBaseInteractionSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = MirTarBaseInteraction
+        fields = [
+            'mirtarbase_id', 'mirna', 'gene', 
+            'target_gene_entrez_id', 'experiments', 
+            'support_type', 'pmid'
+        ]
+

--- a/modulector/templates/index.html
+++ b/modulector/templates/index.html
@@ -1,47 +1,54 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <title>Modulector v{{ version }}</title>
 </head>
+
 <body>
-<h2>Modulector v{{ version }}</h2>
-<ul>
-    <li>
-        <a href="{% url 'mirna' %}">Mirna Details</a>
-    </li>
-    <li>
-        <a href="{% url 'mirna_target_interactions' %}">Mirna Target Interactions</a>
-    </li>
-    <li>
-        <a href="{% url 'mirna_aliases' %}">Mirna Aliases</a>
-    </li>
-    <li>
-        <a href="{% url 'mirna_codes' %}">Mirna Codes</a>
-    </li>
-    <li>
-        <a href="{% url 'mirna_codes_finder' %}">Mirna Codes Finder</a>
-    </li>
-    <li>
-        <a href="{% url 'diseases' %}">Diseases</a>
-    </li>
-    <li>
-        <a href="{% url 'drugs' %}">Drugs</a>
-    </li>
-    <li>
-        <a href="{% url 'methylation' %}">Methylation Details</a>
-    </li>
-    <li>
-        <a href="{% url 'methylation_sites_finder' %}">Illumina Methylation Sites Finder</a>
-    </li>
-    <li>
-        <a href="{% url 'methylation_sites' %}">Illumina Methylation Sites</a>
-    </li>
-    <li>
-        <a href="{% url 'methylation_sites_to_genes' %}">Illumina Methylation Sites to Genes</a>
-    </li>
-</ul>
-<h3>You can use modulector features from the <a href="/api/schema/swagger-ui/" target="_blank">documentation</a> in Swagger</h3>
-<h3><a href="/api/schema/redoc/" target="_blank">Documentation</a> in Redoc</h3>
+    <h2>Modulector v{{ version }}</h2>
+    <ul>
+        <li>
+            <a href="{% url 'mirna' %}">Mirna Details</a>
+        </li>
+        <li>
+            <a href="{% url 'mirna_target_interactions' %}">Mirna Target Interactions</a>
+        </li>
+        <li>
+            <a href="{% url 'mirna_target_validation' %}">Mirna Target Validation</a>
+        </li>
+        <li>
+            <a href="{% url 'mirna_aliases' %}">Mirna Aliases</a>
+        </li>
+        <li>
+            <a href="{% url 'mirna_codes' %}">Mirna Codes</a>
+        </li>
+        <li>
+            <a href="{% url 'mirna_codes_finder' %}">Mirna Codes Finder</a>
+        </li>
+        <li>
+            <a href="{% url 'diseases' %}">Diseases</a>
+        </li>
+        <li>
+            <a href="{% url 'drugs' %}">Drugs</a>
+        </li>
+        <li>
+            <a href="{% url 'methylation' %}">Methylation Details</a>
+        </li>
+        <li>
+            <a href="{% url 'methylation_sites_finder' %}">Illumina Methylation Sites Finder</a>
+        </li>
+        <li>
+            <a href="{% url 'methylation_sites' %}">Illumina Methylation Sites</a>
+        </li>
+        <li>
+            <a href="{% url 'methylation_sites_to_genes' %}">Illumina Methylation Sites to Genes</a>
+        </li>
+    </ul>
+    <h3>You can use modulector features from the <a href="/api/schema/swagger-ui/" target="_blank">documentation</a> in
+        Swagger</h3>
+    <h3><a href="/api/schema/redoc/" target="_blank">Documentation</a> in Redoc</h3>
 </body>
+
 </html>

--- a/modulector/tests/test_mirna.py
+++ b/modulector/tests/test_mirna.py
@@ -154,6 +154,76 @@ class MiRNATests(TestCase):
         egfr_response = client.get('/mirna-target-interactions/', {'gene': 'EGFR'})
         self.assertEqual(response.data['count'], egfr_response.data['count'])
 
+    """ Testing /mirna-target-validation/ endpoint """
+
+    def testMirnaTargetValidation1(self) -> None:
+        """Tests with an invalid mirna"""
+        response = client.get(
+            '/mirna-target-validation/', {'mirna': 'goku_capo'})
+        self.assertEqual(response.status_code, 200)
+        self.__check_pagination(response)
+        self.__check_empty_pagination(response)
+
+    def testMirnaTargetValidation2(self) -> None:
+        """Tests with a valid mirna and target"""
+        response = client.get(
+            '/mirna-target-validation/', {'mirna': 'hsa-miR-122-5p', 'target': 'SLC7A1'})
+        self.assertEqual(response.status_code, 200)
+        self.__check_pagination(response)
+        # Checks all fields
+        data = response.data['results'][0]
+        self.assertIsInstance(data, dict)
+
+        self.assertTrue('id' in data)
+        self.assertIsInstance(data['id'], int)
+
+        self.assertTrue('mirtarbase_id' in data)
+        self.assertIsInstance(data['mirtarbase_id'], str)
+
+        self.assertTrue('mirna' in data)
+        self.assertIsInstance(data['mirna'], str)
+
+        self.assertTrue('gene' in data)
+        self.assertIsInstance(data['gene'], str)
+
+        self.assertTrue('target_gene_entrez_id' in data)
+        self.assertIsInstance(data['target_gene_entrez_id'], str)
+
+        self.assertTrue('experiments' in data)
+        self.assertIsInstance(data['experiments'], list)
+
+        self.assertTrue('support_type' in data)
+        self.assertIsInstance(data['support_type'], str)
+
+        self.assertTrue('pmid' in data)
+        self.assertIsInstance(data['pmid'], str)
+
+    def testMirnaTargetValidation3(self) -> None:
+        """Tests 400 error for mirna-target-validation endpoint due to not specifying parameters"""
+        response = client.get('/mirna-target-validation/')
+        self.assertEqual(response.status_code, 400)
+
+    def testMirnaTargetValidation4(self) -> None:
+        """Tests /mirna-target-validation/ with a valid mirna parameter"""
+        response = client.get('/mirna-target-validation/', {'mirna': 'hsa-miR-122-5p'})
+        self.assertEqual(response.status_code, 200)
+        self.__check_pagination(response)
+
+    def testMirnaTargetValidation5(self) -> None:
+        """Tests /mirna-target-validation/ with a target gene symbol parameter"""
+        response = client.get('/mirna-target-validation/', {'target': 'SLC7A1'})
+        self.assertEqual(response.status_code, 200)
+        self.__check_pagination(response)
+
+    def testMirnaTargetValidation6(self) -> None:
+        """Tests /mirna-target-validation/ with filtering parameters (support_type and experiment)"""
+        response = client.get(
+            '/mirna-target-validation/',
+            {'mirna': 'hsa-miR-122-5p', 'support_type': 'Functional MTI', 'experiment': 'Western blot'}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.__check_pagination(response)
+
     """ Testing /mirna-aliases/ endpoint """
 
     def testMirnaAliases1(self):

--- a/modulector/views.py
+++ b/modulector/views.py
@@ -20,6 +20,7 @@ from modulector.models import (
     MirnaDrug,
     GeneAliases,
     MethylationEPIC,
+    MirTarBaseInteraction,
 )
 from modulector.pagination import StandardResultsSetPagination
 from modulector.serializers import (
@@ -31,6 +32,7 @@ from modulector.serializers import (
     get_mirna_from_accession,
     get_mirna_aliases,
     get_accession_from_mirna,
+    MirTarBaseInteractionSerializer,
 )
 from modulector.services import subscription_service
 from drf_spectacular.utils import extend_schema, OpenApiParameter, OpenApiExample
@@ -238,6 +240,91 @@ class MirnaTargetInteractions(generics.ListAPIView):
             )
 
         return data.filter(score__gte=score) if score else data
+
+
+class MirnaTargetValidation(generics.ListAPIView):
+    """Returns a paginated response with all the validations of a specific miRNA and target (mirna-target-validation endpoint)"""
+
+    serializer_class = MirTarBaseInteractionSerializer
+    pagination_class = StandardResultsSetPagination
+    filter_backends = [filters.OrderingFilter]
+    ordering_fields = ["mirna", "gene"]
+    ordering = ["id"]
+    handler400 = "rest_framework.exceptions.bad_request"
+
+    @extend_schema(
+        tags=["miRNA"],
+        summary="Retrieve miRNA target validations",
+        parameters=[
+            OpenApiParameter(
+                name="mirna",
+                type=str,
+                description="miRNA to get its targets validation.",
+                required=False,
+                examples=[
+                    OpenApiExample(name="hsa-miR-21-5p", value="hsa-miR-21-5p"),
+                ],
+            ),
+            OpenApiParameter(
+                name="target",
+                type=str,
+                description="Gene symbol (target) to get its interactions with different miRNAs",
+                required=False,
+                examples=[
+                    OpenApiExample(name="EGFR", value="EGFR"),
+                ],
+            ),
+            OpenApiParameter(
+                name="support_type",
+                type=str,
+                description="Filter by support type.",
+                required=False,
+                enum=['Functional MTI', 'Functional MTI (Weak)', 'Non-Functional MTI', 'Non-Functional MTI (Weak)'],
+            ),
+            OpenApiParameter(
+                name="experiment",
+                type=str,
+                description="Filter by experiment type.",
+                required=False,
+            ),
+            # Exclude pagination and ordering parameters
+            OpenApiParameter(name="ordering", exclude=True),
+            OpenApiParameter(name="page", exclude=True),
+            OpenApiParameter(name="page_size", exclude=True),
+        ],
+    )
+    def get(self, request, *args, **kwargs):
+        """
+        Receives a miRNA and/or a target gene and returns a paginated vector. Each vector entry represents a miRNA-Gene validation interaction in MirTarBase. If no target is entered, all targets for that miRNA are returned. If a miRNA is not entered, all miRNA interactions for that target are returned. If both are entered, the interactions of the mirna with the target are returned.
+        """
+        return super().get(request, *args, **kwargs)
+
+    def get_queryset(self):
+        mirna = self.request.GET.get("mirna")
+        target = self.request.GET.get("target")
+        support_type = self.request.GET.get("support_type")
+        experiment = self.request.GET.get("experiment")
+
+        if not mirna and not target:
+            raise ParseError(detail="'mirna' or 'target' are mandatory")
+
+        if support_type:
+            valid_support_types = ['Functional MTI', 'Functional MTI (Weak)', 'Non-Functional MTI', 'Non-Functional MTI (Weak)']
+            if support_type not in valid_support_types:
+                raise ParseError(detail=f"Invalid 'support_type'. Allowed values are: {', '.join(valid_support_types)}")
+
+        data = MirTarBaseInteraction.objects.all()
+        
+        if mirna:
+            data = data.filter(mirna=mirna)
+        if target:
+            data = data.filter(gene=target)
+        if support_type:
+            data = data.filter(support_type=support_type)
+        if experiment:
+            data = data.filter(experiments__icontains=experiment)
+
+        return data
 
 
 class MirnaAliasesList(generics.ListAPIView):

--- a/modulector/views.py
+++ b/modulector/views.py
@@ -98,7 +98,6 @@ class MirnaTargetInteractions(generics.ListAPIView):
     filter_backends = [filters.OrderingFilter]
     ordering_fields = ["gene", "score"]
     ordering = ["id"]
-    handler400 = "rest_framework.exceptions.bad_request"
 
     @staticmethod
     def __get_gene_aliases(gene: str) -> list[str]:
@@ -247,10 +246,10 @@ class MirnaTargetValidation(generics.ListAPIView):
 
     serializer_class = MirTarBaseInteractionSerializer
     pagination_class = StandardResultsSetPagination
-    filter_backends = [filters.OrderingFilter]
+    filter_backends = [filters.OrderingFilter, DjangoFilterBackend]
+    filterset_fields = ["mirna", "gene", "support_type"]
     ordering_fields = ["mirna", "gene"]
     ordering = ["id"]
-    handler400 = "rest_framework.exceptions.bad_request"
 
     @extend_schema(
         tags=["miRNA"],
@@ -301,7 +300,7 @@ class MirnaTargetValidation(generics.ListAPIView):
 
     def get_queryset(self):
         mirna = self.request.GET.get("mirna")
-        target = self.request.GET.get("target")
+        target = self.request.GET.get("target") or self.request.GET.get("gene")
         support_type = self.request.GET.get("support_type")
         experiment = self.request.GET.get("experiment")
 
@@ -314,13 +313,9 @@ class MirnaTargetValidation(generics.ListAPIView):
                 raise ParseError(detail=f"Invalid 'support_type'. Allowed values are: {', '.join(valid_support_types)}")
 
         data = MirTarBaseInteraction.objects.all()
-        
-        if mirna:
-            data = data.filter(mirna=mirna)
-        if target:
+        # The 'target' query parameter maps to the 'gene' field in the model
+        if self.request.GET.get("target") and not self.request.GET.get("gene"):
             data = data.filter(gene=target)
-        if support_type:
-            data = data.filter(support_type=support_type)
         if experiment:
             data = data.filter(experiments__icontains=experiment)
 


### PR DESCRIPTION
This pull request adds a new "miRNA target validation" feature to the Modulector application, allowing users to query experimentally validated miRNA-target interactions from the miRTarBase database. The implementation includes model, migration, serializer, view, and documentation updates, as well as UI and URL routing changes. The main changes are grouped as follows:

**New miRNA Target Validation Feature:**

* Added a new endpoint `/mirna-target-validation` to the API, which allows querying experimentally validated miRNA-target interactions, with support for filtering by miRNA, target gene, support type, and experiment type. The endpoint is paginated and documented in the API docs.
* Updated the main HTML template (`index.html`) to include a link to the new miRNA target validation feature.

**Database and Model Changes:**

* Modified the `MirTarBaseInteraction` model and migration to add a `target_gene_entrez_id` field and change `experiments` from a single string to a Postgres array of strings, improving the structure and queryability of experiment data.
* Updated the migration script to properly parse and clean experiment and Entrez ID fields from the data source.

**Serialization and API Integration:**

* Added a new serializer, `MirTarBaseInteractionSerializer`, to ensure proper serialization of the new model fields for API responses.
* Integrated the serializer and model into the views and imports. 

**Documentation Updates:**

* Updated the `README.md` to document the new endpoint, its parameters, response structure, and its data source (miRTarBase v11.0). Also updated the list of data sources to include miRTarBase. 

**UI and Routing:**

* Registered the new endpoint in `urls.py` and added a link to it in the main HTML template for discoverability. 

These changes collectively introduce a robust, well-documented, and user-accessible miRNA target validation feature based on curated experimental data.